### PR TITLE
Chore/add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Cargo Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81.0
+
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo nextest run --release --workspace --all --all-features --no-capture
+        env:
+          SP1_PRIVATE_KEY: ${{ secrets.SP1_PRIVATE_KEY }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  prepare:
+    name: Dokcer tag
+    runs-on: ubuntu-latest
+    outputs:
+      docker-tag: ${{ steps.docker-tag.outputs.tag }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Docker Image Name
+        id: docker-tag
+        run: |
+          # Extract the version from Cargo.toml
+          VERSION=$(grep '^version' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/')
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build Docker Images
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.proverproxy.ubuntu
+          push: true
+          tags: kromanetwork/zkvm-prover-proxy:${{ needs.prepare.outputs.docker-tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ target/
 
 .env
 
-data/
+/data
 
 prover-proxy/tests/data/proof.json


### PR DESCRIPTION
This PR adds CI using GitHub Actions. The CI process includes running cargo test which requests generating proof to real sp1 prover network. And it also includes pushing Docker images after building them. The Docker image tag references the version string specified in `Cargo.toml`.
